### PR TITLE
[SC-71150] fix: resolve Snyk vulnerabilities in redash

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ python-dateutil==2.8.0
 pytz>=2019.3
 PyYAML==5.4
 redis==3.5.0
-requests==2.32.4
+requests==2.33.0
 SQLAlchemy==1.3.10
 # We can't upgrade SQLAlchemy-Searchable version as newer versions require PostgreSQL > 9.6, but we target older versions at the moment.
 SQLAlchemy-Searchable==0.10.6
@@ -48,7 +48,7 @@ xlsxwriter==1.2.2
 pystache==0.5.4
 parsedatetime==2.4
 PyJWT==2.4.0
-cryptography==45.0.5
+cryptography==46.0.7
 simplejson==3.16.0
 ua-parser==0.8.0
 user-agents==2.0
@@ -65,4 +65,4 @@ werkzeug==2.3.7
 # ldap3==2.2.4
 Authlib==0.15.5
 advocate==1.0.0
-urllib3>=1.25.9 # not directly required, pinned by Snyk to avoid a vulnerability
+urllib3>=2.6.3 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
## Summary
- Upgrade 3 Python dependencies in `requirements.txt` to resolve Snyk High/Medium findings
- No code changes, no lockfile changes, no Dockerfile changes

## Dependency Changes
| Package | Old | New | Severity Fixed |
|---------|-----|-----|---------------|
| cryptography | 45.0.5 | 46.0.7 | 1 High (Insufficient Verification) + 2 Medium |
| requests | 2.32.4 | 2.33.0 | Medium (Insecure Temporary File) |
| urllib3 | >=1.25.9 | >=2.6.3 | High (Improper Handling of Compressed Data) |

## Snyk Scan Results (Open Source)
| | Critical | High | Medium |
|---|---------|------|--------|
| **Before** | 0 | 2 | 4 |
| **After** | 0 | 0 | 1 |

### Residual (unfixable)
- `certifi` — MPL-2.0 license issue, no fix available
- Container image `python:3.8.18-slim` — 5C, 14H, 16M (Python 3.8 is EOL, no patch available within 3.8.x)
- Node `node:14.21.3` build stage — Node 14 is EOL (build-only, not in runtime image)

## Test plan
- [x] `snyk test --file=requirements.txt --skip-unresolved` confirms 0C, 0H
- [x] Changes are version bumps only — no code changes
- [ ] CI passes (tests require docker-compose + postgres)

🤖 Generated with [Claude Code](https://claude.com/claude-code)